### PR TITLE
Fix default branch for googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (OSQP-CPP_BUILD_TESTS)
     FetchContent_Declare(
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG        origin/master
+      GIT_TAG        origin/main
     )
     FetchContent_MakeAvailable(googletest)
     include(GoogleTest)


### PR DESCRIPTION
Default branch changed from master to main in googletest repository.