### PR TITLE
Update osqp git repository

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ if (NOT TARGET osqpstatic)
   message(STATUS "osqp-cpp: `osqp` targets not found. Attempting to fetch contents...")
   FetchContent_Declare(
     osqp
-    GIT_REPOSITORY https://github.com/oxfordcontrol/osqp.git
-    GIT_TAG        origin/master
+    GIT_REPOSITORY https://github.com/osqp/osqp
+    GIT_TAG        v0.6.3
   )
   FetchContent_MakeAvailable(osqp)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if (NOT TARGET osqpstatic)
   message(STATUS "osqp-cpp: `osqp` targets not found. Attempting to fetch contents...")
   FetchContent_Declare(
     osqp
-    GIT_REPOSITORY https://github.com/osqp/osqp
+    GIT_REPOSITORY https://github.com/osqp/osqp.git
     GIT_TAG        v0.6.3
   )
   FetchContent_MakeAvailable(osqp)


### PR DESCRIPTION
The osqp master branch is no longer compatible, this PR sets the tag to the latest compatible release (v0.6.3) and updates the repository url which moved.

Related to https://github.com/google/osqp-cpp/issues/23